### PR TITLE
Add documentation for Range and SelectorsInfo structures

### DIFF
--- a/plonk/gates/types.go
+++ b/plonk/gates/types.go
@@ -2,16 +2,20 @@ package gates
 
 const UNUSED_SELECTOR = uint64(^uint32(0)) // max uint32
 
+// Range defines a range with a start and end value.
 type Range struct {
 	start uint64
 	end   uint64
 }
 
+// SelectorsInfo stores information about selectors and their groups.
 type SelectorsInfo struct {
-	selectorIndices []uint64
-	groups          []Range
+	selectorIndices []uint64 // Indices of selectors.
+	groups          []Range  // Ranges defining groups of selectors.
 }
 
+// NewSelectorsInfo creates a new SelectorsInfo instance.
+// It validates that groupStarts and groupEnds have the same length.
 func NewSelectorsInfo(selectorIndices []uint64, groupStarts []uint64, groupEnds []uint64) *SelectorsInfo {
 	if len(groupStarts) != len(groupEnds) {
 		panic("groupStarts and groupEnds must have the same length")
@@ -31,6 +35,7 @@ func NewSelectorsInfo(selectorIndices []uint64, groupStarts []uint64, groupEnds 
 	}
 }
 
+// NumSelectors returns the number of selector groups.
 func (s *SelectorsInfo) NumSelectors() uint64 {
 	return uint64(len(s.groups))
 }


### PR DESCRIPTION
- Added comments to the `Range` struct explaining its purpose and fields.
- Documented the `SelectorsInfo` struct with details about selector indices and groups.
- Provided a detailed description for the `NewSelectorsInfo` constructor, including validation logic.
- Added a comment to the `NumSelectors` method to clarify its functionality.
- Improved code readability and maintainability through comprehensive inline documentation.